### PR TITLE
retain some options. Possibly addresses #34

### DIFF
--- a/src/main/java/io/github/openunirest/http/Unirest.java
+++ b/src/main/java/io/github/openunirest/http/Unirest.java
@@ -136,10 +136,18 @@ public class Unirest {
 
     /**
      * Close the asynchronous client and its event loop. Use this method to close all the threads and allow an application to exit.
-     *
+     * This will also clear any options returning Unirest to a default state
      */
     public static void shutdown() {
-       Options.shutDown();
+       shutdown(true);
+    }
+
+    /**
+     * Close the asynchronous client and its event loop. Use this method to close all the threads and allow an application to exit.
+     * @param clearOptions  indicates if options should be cleared. Note that the HttpClient, AsyncClient and thread monitors will not be retained after shutdown.
+     */
+    public static void shutdown(boolean clearOptions) {
+        Options.shutDown(clearOptions);
     }
 
     public static GetRequest get(String url) {

--- a/src/main/java/io/github/openunirest/http/options/Option.java
+++ b/src/main/java/io/github/openunirest/http/options/Option.java
@@ -1,17 +1,28 @@
 package io.github.openunirest.http.options;
 
 public enum Option {
-	HTTPCLIENT,
-	ASYNCHTTPCLIENT,
+	HTTPCLIENT(false),
+	ASYNCHTTPCLIENT(false),
 	CONNECTION_TIMEOUT,
 	SOCKET_TIMEOUT,
 	DEFAULT_HEADERS,
-	SYNC_MONITOR,
-	ASYNC_MONITOR,
+	SYNC_MONITOR(false),
+	ASYNC_MONITOR(false),
 	MAX_TOTAL,
 	MAX_PER_ROUTE,
 	PROXY,
 	OBJECT_MAPPER,
 	FOLLOW_REDIRECTS,
-	COOKIE_MANAGEMENT
+	COOKIE_MANAGEMENT;
+
+	private final boolean canSurviveShutdown;
+
+	Option(){this(true);}
+	Option(boolean canSurviveShutdown){
+		this.canSurviveShutdown = canSurviveShutdown;
+	}
+
+	public boolean canSurviveShutdown() {
+		return canSurviveShutdown;
+	}
 }


### PR DESCRIPTION
@jdbevan can you please look at this and let me know if this would work for you. You would be able to keep some options by passing an optional flag to the shutdown method that tells it to clear the options. 

so 
```
Unirest.shutDown(false)
```

The clients and thread monitors are not retained since they were shut down.