### PR TITLE
add isSuccess() method to HttpResponse interface

### DIFF
--- a/src/main/java/unirest/BaseResponse.java
+++ b/src/main/java/unirest/BaseResponse.java
@@ -100,7 +100,8 @@ abstract class BaseResponse<T> implements HttpResponse<T> {
         return this;
     }
 
-    private boolean isSuccess() {
+    @Override
+    public boolean isSuccess() {
         return getStatus() >= 200 && getStatus() < 300 && !getParsingError().isPresent();
     }
 }

--- a/src/main/java/unirest/HttpResponse.java
+++ b/src/main/java/unirest/HttpResponse.java
@@ -106,4 +106,9 @@ public interface HttpResponse<T> {
      * @return the same response
      */
     HttpResponse<T> ifFailure(Consumer<HttpResponse<T>> consumer);
+
+     /**
+     * @return true if the response was a 200-series response and no mapping exception happened, else false
+     */
+    boolean isSuccess();
 }

--- a/src/test/java/BehaviorTests/PostRequestHandlersTest.java
+++ b/src/test/java/BehaviorTests/PostRequestHandlersTest.java
@@ -83,4 +83,35 @@ public class PostRequestHandlersTest extends BddTest {
         assertTrue(captured.getParsingError().isPresent());
         assertEquals("not what you expect", captured.getParsingError().get().getOriginalBody());
     }
+
+
+
+    @Test
+    public void onSuccessBeSuccessful() {
+        HttpResponse<RequestCapture> response = Unirest.get(MockServer.GET)
+            .queryString("foo", "bar")
+            .asObject(RequestCapture.class);
+
+        assertTrue(response.isSuccess());
+    }
+
+    @Test
+    public void onFailBeUnsuccessful() {
+        HttpResponse<RequestCapture> response = Unirest.get(MockServer.INVALID_REQUEST)
+            .queryString("foo", "bar")
+            .asObject(RequestCapture.class);
+
+        assertFalse(response.isSuccess());
+    }
+
+    @Test
+    public void beUnsuccessfulIfTheMapperFails() {
+        MockServer.setStringResponse("not what you expect");
+
+        HttpResponse<RequestCapture> response = Unirest.get(MockServer.GET)
+            .queryString("foo", "bar")
+            .asObject(RequestCapture.class);
+
+        assertFalse(response.isSuccess());
+    }
 }


### PR DESCRIPTION
this would add an isSuccess() method to HttpResponses for easy check if the response object was parsed and processed correctly or if I need to start error handling. 
- as an alternative to the ifSuccess() and ifFailure() methods if one doesn't want to write Consumers for everything.